### PR TITLE
Fix: Adjust Gemini API payload schema in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,7 @@
                 <label for="textInput">Insira o texto base para o seu mapa mental:</label>
                 <textarea id="textInput" placeholder="Ex: Planejamento de um projeto, resumo de um livro, ideias para um novo negócio..."></textarea>
             </div>
-            <div class="input-group" style="margin-bottom: 25px;"> {/* Added margin-bottom here */}
+            <div class="input-group" style="margin-bottom: 25px;"> <!-- Added margin-bottom here -->
                 <label for="layoutSelect">Escolha o Layout do Mapa:</label>
                 <select id="layoutSelect">
                     <option value="organic">Orgânico (Padrão)</option>
@@ -739,8 +739,8 @@ ${text}
             const grandChildItemSchema = {
                 type: "object",
                 properties: { "title": { type: "string" } },
-                required: ["title"],
-                additionalProperties: false // Impede propriedades extras
+                required: ["title"]
+                // additionalProperties: false // Impede propriedades extras
             };
 
             const childItemSchema = {
@@ -749,8 +749,8 @@ ${text}
                     "title": { type: "string" },
                     "children": { type: "array", items: grandChildItemSchema }
                 },
-                required: ["title"],
-                additionalProperties: false
+                required: ["title"]
+                // additionalProperties: false
             };
 
             const branchItemSchema = {
@@ -759,8 +759,8 @@ ${text}
                     "title": { type: "string" },
                     "children": { type: "array", items: childItemSchema }
                 },
-                required: ["title"],
-                additionalProperties: false
+                required: ["title"]
+                // additionalProperties: false
             };
 
             const mindMapSchema = {
@@ -769,8 +769,8 @@ ${text}
                     "central": { type: "string" },
                     "branches": { type: "array", items: branchItemSchema }
                 },
-                required: ["central"],
-                additionalProperties: false
+                required: ["central"]
+                // additionalProperties: false
             };
 
             const payload = {
@@ -817,8 +817,6 @@ ${text}
             } catch (e) {
                 throw new Error(`A IA retornou um JSON inválido ou mal formatado: ${generatedText.substring(0, 200)}. Erro: ${e.message}`);
             }
-        }
-
         }
 
 


### PR DESCRIPTION
Removed 'additionalProperties: false' from the responseSchema definitions (mindMapSchema, branchItemSchema, childItemSchema, grandChildItemSchema) within the callGeminiAPI function.

This change addresses a 400 Bad Request error where the Gemini API reported an unknown name "additionalProperties" in the schema, allowing successful mind map generation.